### PR TITLE
fix: use warn instead of error when can't parse file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export const injectDataQa: PluginImpl<InjectDataQaParams> = ({
 		try {
 			ast = parse(code)
 		} catch (error) {
-			this.error(error)
+			this.warn(`${id} - ${error}`)
 		}
 
 		if (!ast) return UNCHANGED


### PR DESCRIPTION
In case the file can't be parsed, use a warning instead of an error to ensure the transform continues to work.