### PR TITLE
feat: support svg

### DIFF
--- a/src/utils/isObjectAssigning/index.ts
+++ b/src/utils/isObjectAssigning/index.ts
@@ -1,0 +1,3 @@
+export default function isObjectAssigning(node: Record<string, any>) {
+	return node.callee?.object?.name === 'Object' && node.callee?.property?.name === 'assign'
+}

--- a/src/utils/magicString/insertToObject/index.ts
+++ b/src/utils/magicString/insertToObject/index.ts
@@ -1,0 +1,10 @@
+import { IS_E2E_ENABLED } from 'pluginConstants'
+
+import { InsertToObjectParams } from './types'
+
+export default function insertToObject({ code, node, attrs }: InsertToObjectParams) {
+	if (node?.type === 'ObjectExpression') {
+		// NOTE: start position is `{` so we will increase 1 for insert behind it.
+		code.appendLeft(node.start + 1, `...(${IS_E2E_ENABLED} && ${JSON.stringify(attrs)}),`)
+	}
+}

--- a/src/utils/magicString/insertToObject/types.ts
+++ b/src/utils/magicString/insertToObject/types.ts
@@ -1,0 +1,7 @@
+import MagicString from 'magic-string'
+
+export interface InsertToObjectParams {
+	code: MagicString
+	node: Record<string, any>
+	attrs: Record<string, any>
+}

--- a/src/utils/magicString/react/isReactNode/index.ts
+++ b/src/utils/magicString/react/isReactNode/index.ts
@@ -5,7 +5,9 @@ export default function isReactNode(node: Record<string, any>) {
 	const isJsxAndNotFragment =
 		(node?.callee?.name === 'jsxDEV' ||
 			node?.callee?.name === 'jsx' ||
-			node?.callee?.name === 'jsxs') &&
+			node?.callee?.name === '_jsx' ||
+			node?.callee?.name === 'jsxs' ||
+			node?.callee?.name === '_jsxs') &&
 		node?.arguments?.[0]?.name !== 'Fragment'
 
 	return isReactCreateElement || isJsxAndNotFragment


### PR DESCRIPTION
support below case

```
// svg -> svg will transform to '_jsxs'
const Componet = () => <svg>...</svg>

// no props
const Componet = () => <div />
const Componet = () => <svg />

// with deconstruct object props
const Componet = () => <div {...{ key:value }} />
const Componet = () => <svg {...{ key:value }} />
```
