### PR TITLE
fix: improve isReactNode (also check _Fragment)

### DIFF
--- a/src/pluginConstants.ts
+++ b/src/pluginConstants.ts
@@ -3,3 +3,7 @@ export const IS_E2E_ENABLED = "process.env.E2E_ENABLED === 'true'"
 export const UNCHANGED = null
 
 export const DATA_QA = 'data-qa'
+
+export const JSX_CALLEE_NAMES = ['jsxDEV', 'jsx', '_jsx', 'jsxs', '_jsxs']
+
+export const FRAGMENT_NAMES = ['Fragment', '_Fragment']

--- a/src/utils/magicString/react/isReactNode/index.ts
+++ b/src/utils/magicString/react/isReactNode/index.ts
@@ -1,14 +1,12 @@
+import { FRAGMENT_NAMES, JSX_CALLEE_NAMES } from 'pluginConstants'
+
 export default function isReactNode(node: Record<string, any>) {
 	const isReactCreateElement =
 		node?.callee?.object?.name === 'React' && node?.callee?.property?.name === 'createElement'
 
 	const isJsxAndNotFragment =
-		(node?.callee?.name === 'jsxDEV' ||
-			node?.callee?.name === 'jsx' ||
-			node?.callee?.name === '_jsx' ||
-			node?.callee?.name === 'jsxs' ||
-			node?.callee?.name === '_jsxs') &&
-		node?.arguments?.[0]?.name !== 'Fragment'
+		JSX_CALLEE_NAMES.includes(node?.callee?.name) &&
+		!FRAGMENT_NAMES.includes(node?.arguments?.[0]?.name)
 
 	return isReactCreateElement || isJsxAndNotFragment
 }


### PR DESCRIPTION
We also should not consider node that have argument[0].name equal to _Fragment as React node.

| Before | After |
|------------|------------|
| <img width="715" alt="SCR-20241010-jgcd" src="https://github.com/user-attachments/assets/97c1fb01-ee56-49a0-a64f-0e51ba9f7a61"> | <img width="821" alt="SCR-20241010-jqtn" src="https://github.com/user-attachments/assets/457e4f31-7f39-4470-a4c0-ef8684aba1cd"> |